### PR TITLE
tests: cycling_mode fixture

### DIFF
--- a/cylc/flow/tests/conftest.py
+++ b/cylc/flow/tests/conftest.py
@@ -1,0 +1,32 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import pytest
+
+from cylc.flow.cycling.loader import (
+    ISO8601_CYCLING_TYPE,
+    INTEGER_CYCLING_TYPE
+)
+
+
+@pytest.fixture
+def cycling_mode(monkeypatch):
+    """Set the Cylc cycling mode."""
+    def _cycling_mode(integer=True):
+        monkeypatch.setattr(
+            'cylc.flow.cycling.loader.DefaultCycler.TYPE',
+            (INTEGER_CYCLING_TYPE if integer else ISO8601_CYCLING_TYPE)
+        )
+    return _cycling_mode


### PR DESCRIPTION
@MetRonnie here's a pytest fixture to make that KeyError go away.

Call the fixture from a test function like so:

```
def test_mytest(cycling_mode):
    cycling_mode()

     # the rest of the test
```