### PR TITLE
tests: make restart/52 more dependable

### DIFF
--- a/tests/restart/52-cycle-point-time-zone.t
+++ b/tests/restart/52-cycle-point-time-zone.t
@@ -46,20 +46,24 @@ run_ok "${TEST_NAME_BASE}-validate" cylc validate "${SUITE_NAME}"
 # Set time zone to +01:00
 export TZ=BST-1
 
-suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-run" cylc run "${SUITE_NAME}" --hold
+poll_suite_running
+cylc stop "${SUITE_NAME}"
+poll_suite_stopped
+
 dumpdbtables
 cmp_ok 'dump.out' <<< 'cycle_point_tz|+0100'
-
-cylc stop "${SUITE_NAME}"
 
 # Simulate DST change
 export TZ=UTC
 
-suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}"
+suite_run_ok "${TEST_NAME_BASE}-restart" cylc restart "${SUITE_NAME}" --hold
+poll_suite_running
+cylc stop "${SUITE_NAME}"
+poll_suite_stopped
+
 dumpdbtables
 cmp_ok 'dump.out' <<< 'cycle_point_tz|+0100'
-
-cylc stop "${SUITE_NAME}"
 
 purge_suite "${SUITE_NAME}"
 exit


### PR DESCRIPTION
Make that flaky test more dependable. @MetRonnie 

The Cylc test battery is very vulnerable to timing issues, kinda natural as we are trying to test a scheduling engine.