### PR TITLE
hold: update task state in the n=1 window

### DIFF
--- a/cylc/flow/data_store_mgr.py
+++ b/cylc/flow/data_store_mgr.py
@@ -60,6 +60,7 @@ from collections import Counter, deque
 from copy import deepcopy
 import json
 from time import time
+from typing import Union, Tuple, TYPE_CHECKING
 import zlib
 
 from cylc.flow import __version__ as CYLC_VERSION, LOG, ID_DELIM
@@ -91,6 +92,9 @@ from cylc.flow.wallclock import (
     get_utc_mode,
     get_time_string_from_unix_time as time2str
 )
+
+if TYPE_CHECKING:
+    from cylc.flow.cyclers import PointBase
 
 
 EDGES = 'edges'
@@ -797,6 +801,10 @@ class DataStoreMgr:
             id=tp_id,
             task=t_id,
             cycle_point=point_string,
+            is_held=(
+                (itask.tdef.name, itask.point)
+                in self.schd.pool.tasks_to_hold
+            ),
             depth=task_def.depth,
             name=task_def.name,
             state=TASK_STATUS_WAITING,
@@ -1448,22 +1456,32 @@ class DataStoreMgr:
                     PbTask(id=t_id)).MergeFrom(t_delta)
         self.updates_pending = True
 
-    def delta_task_held(self, itask):
+    def delta_task_held(
+        self,
+        itask: Union[TaskProxy, Tuple[str, 'PointBase', bool]]
+    ):
         """Create delta for change in task proxy held state.
 
         Args:
-            itask (cylc.flow.task_proxy.TaskProxy):
-                Update task-node from corresponding task proxy
-                objects from the workflow task pool.
+            itask:
+                The TaskProxy to hold/release OR a tuple of the form
+                (name, cycle, is_held).
 
         """
-        tp_id, tproxy = self.store_node_fetcher(itask.tdef.name, itask.point)
+        if isinstance(itask, TaskProxy):
+            name = itask.tdef.name
+            cycle = itask.point
+            is_held = itask.state.is_held
+        else:
+            name, cycle, is_held = itask
+
+        tp_id, tproxy = self.store_node_fetcher(name, cycle)
         if not tproxy:
             return
         tp_delta = self.updated[TASK_PROXIES].setdefault(
             tp_id, PbTaskProxy(id=tp_id))
         tp_delta.stamp = f'{tp_id}@{time()}'
-        tp_delta.is_held = itask.state.is_held
+        tp_delta.is_held = is_held
         self.state_update_families.add(tproxy.first_parent)
         self.updates_pending = True
 

--- a/cylc/flow/task_pool.py
+++ b/cylc/flow/task_pool.py
@@ -1038,6 +1038,8 @@ class TaskPool:
             self.hold_active_task(itask)
         # Set future tasks to be held:
         n_warnings, task_items = self._explicit_match_tasks_to_hold(unmatched)
+        for name, cycle in task_items:
+            self.data_store_mgr.delta_task_held((name, cycle, True))
         self.tasks_to_hold.update(task_items)
         self.workflow_db_mgr.put_tasks_to_hold(self.tasks_to_hold)
         LOG.debug(f"Tasks to hold: {self.tasks_to_hold}")
@@ -1051,6 +1053,8 @@ class TaskPool:
             self.release_held_active_task(itask)
         # Unhold future tasks:
         n_warnings, task_items = self._explicit_match_tasks_to_hold(unmatched)
+        for name, cycle in task_items:
+            self.data_store_mgr.delta_task_held((name, cycle, False))
         self.tasks_to_hold.difference_update(task_items)
         self.workflow_db_mgr.put_tasks_to_hold(self.tasks_to_hold)
         LOG.debug(f"Tasks to hold: {self.tasks_to_hold}")


### PR DESCRIPTION
Shim the data store so that the n=1 tasks reflect the correct status.

Test with `cylc tui`, a graph like this should do:

```
a[-P1] => a
```

* If task a.1 is in the pool then you should also see `a.2`.
* If you hold `a.2` and `a.3` then `a.2` should update as held.
* If you trigger `a.1` it should run, then `a.3` should appear as held.